### PR TITLE
CI - Add auto build for windows, linux and mac

### DIFF
--- a/.github/workflows/latest-main.yaml
+++ b/.github/workflows/latest-main.yaml
@@ -1,0 +1,63 @@
+name: Build
+
+on: [ push ]
+
+defaults:
+  run:
+    working-directory: app
+
+jobs:
+  windows-build:
+    runs-on: windows-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+        cache: 'gradle'
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+    - name: Build with Gradle
+      run: ./gradlew packageReleaseMsi
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Boardwalk-Timer-windows-amd64
+        path: D:\a\boardwalk-timer-kotlin\boardwalk-timer-kotlin\app\composeApp\build\compose\binaries\main-release\msi\Boardwalk-Timer*.msi
+  linux-build:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+        cache: 'gradle'
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+    - name: Build with Gradle
+      run: ./gradlew packageReleaseDeb
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Boardwalk-Timer-debian-amd64
+        path: /home/runner/work/boardwalk-timer-kotlin/boardwalk-timer-kotlin/app/composeApp/build/compose/binaries/main-release/deb/boardwalk-timer_*.deb
+  macos-build:
+    runs-on: macos-latest
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v4
+    - uses: actions/setup-java@v4
+      with:
+        distribution: 'temurin'
+        java-version: '21'
+        cache: 'gradle'
+    - name: Setup Gradle
+      uses: gradle/actions/setup-gradle@v3
+    - name: Build with Gradle
+      run: ./gradlew packageReleaseDmg
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Boardwalk-Timer-macos-arm64
+        path: /Users/runner/work/boardwalk-timer-kotlin/boardwalk-timer-kotlin/app/composeApp/build/compose/binaries/main-release/dmg/Boardwalk-Timer-*.dmg


### PR DESCRIPTION
This change will automatically build and upload packages for windows-amd64, linux-amd64 and mac-arm64.